### PR TITLE
refactor: 캘린더 주말 색상 스타일 수정, edit 페이지 연결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,14 +6,15 @@ import Intro from "./pages/Intro";
 import TodoMain from "./pages/TodoMain";
 import TodoList from "./pages/TodoList";
 import TodoWrite from "./pages/TodoWrite";
+import TodoWriteEdit from "./pages/TodoWriteEdit";
 import MyPlantList from "./pages/MyPlantList";
 import MyPlantWrite from "./pages/MyPlantWrite";
 import MyPlantDetail from "./pages/MyPlantDetail";
 import MyPlantDetailEdit from "./pages/MyPlantDetailEdit";
-import DiaryWrite from "./pages/DiaryWrite";
-import DiaryWriteEdit from "./pages/DiaryWriteEdit";
 import DiaryList from "./pages/DiaryList";
+import DiaryWrite from "./pages/DiaryWrite";
 import DiaryDetail from "./pages/DiaryDetail";
+import DiaryWriteEdit from "./pages/DiaryWriteEdit";
 import NotFound from "./pages/NotFound";
 
 function App() {
@@ -25,14 +26,15 @@ function App() {
           <Route index element={<TodoMain />} />
           <Route path="/todolist" element={<TodoList />} />
           <Route path="/todowrite" element={<TodoWrite />} />
+          <Route path="/todoedit" element={<TodoWriteEdit />} />
           <Route path="/myplantlist" element={<MyPlantList />} />
           <Route path="/myplantwrite" element={<MyPlantWrite />} />
           <Route path="/myplantdetail" element={<MyPlantDetail />} />
-          <Route path="/myplantdetailedit" element={<MyPlantDetailEdit />} />
-          <Route path="/diarywrite" element={<DiaryWrite />} />
-          <Route path="/diarywriteedit" element={<DiaryWriteEdit />} />
+          <Route path="/myplantedit" element={<MyPlantDetailEdit />} />
           <Route path="/diarylist" element={<DiaryList />} />
+          <Route path="/diarywrite" element={<DiaryWrite />} />
           <Route path="/diarydetail" element={<DiaryDetail />} />
+          <Route path="/diaryedit" element={<DiaryWriteEdit />} />
           <Route path="/*" element={<NotFound />} />
         </Route>
       </Routes>

--- a/src/components/TodoListItem.js
+++ b/src/components/TodoListItem.js
@@ -12,18 +12,12 @@ import {
 } from "../style/ListLayout";
 
 const TodoListItem = ({ todoListData, toggleItem }) => {
-  // switch 토글 이벤트
-  // const onChange = (checked, id) => {
-  //   // todoToggle();
-  //   // setSelectSwitch(id);
-  //   console.log(`switch to ${checked}`);
-  // };
   return (
     <>
       {todoListData.map((item, idx) => (
         <ListItem key={item.id}>
           {/* Todo 수정 버튼 */}
-          <Link to="/" />
+          <Link to="/todoedit" />
           <ItemLeft>
             {/* switch */}
             <ConfigProvider

--- a/src/pages/DiaryDetail.js
+++ b/src/pages/DiaryDetail.js
@@ -42,7 +42,7 @@ const DiaryDetail = () => {
           </p>
           <PageBtnWrap>
             <li>
-              <Link to="/">수정</Link>
+              <Link to="/diaryedit">수정</Link>
             </li>
             <li>
               <button onClick={showModal}>삭제</button>

--- a/src/pages/MyPlantDetail.js
+++ b/src/pages/MyPlantDetail.js
@@ -54,7 +54,7 @@ const MyPlantDetail = () => {
           </p>
           <PageBtnWrap>
             <li>
-              <Link to="/">수정</Link>
+              <Link to="/myplantedit">수정</Link>
             </li>
             <li>
               <button onClick={showModal}>삭제</button>

--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -1,15 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { WriteBtn } from "../style/ListLayout";
 import TodoListItem from "../components/TodoListItem";
 
 const TodoList = () => {
-  // switch 클릭 시 글자 색상 변경되는 클래스 관리하는 state
-  // const [todoSwitch, setTodoSwitch] = useState(true);
-  // // 투두 리스트 state
-  // const todoToggle = () => {
-  //   setTodoSwitch(!todoSwitch);
-  // };
   // 투두리스트 더미데이터
   const [todoListData, setTodoListData] = useState([
     {
@@ -60,12 +54,7 @@ const TodoList = () => {
   return (
     <>
       <ul>
-        <TodoListItem
-          // todoSwitch={todoSwitch}
-          // todoToggle={todoToggle}
-          todoListData={todoListData}
-          toggleItem={toggleItem}
-        />
+        <TodoListItem todoListData={todoListData} toggleItem={toggleItem} />
       </ul>
       <WriteBtn>
         <Link to="/todowrite"></Link>

--- a/src/pages/TodoWriteEdit.js
+++ b/src/pages/TodoWriteEdit.js
@@ -1,0 +1,250 @@
+import React from "react";
+import { Select, Input, Checkbox, Form } from "antd";
+import { TodoWriteFir, TodoWriteTxt } from "../style/WriteLayout";
+import { ConfigProvider } from "antd";
+import { height, mainColor } from "../style/GlobalStyle";
+import { PageBtnWrap } from "../style/Components";
+import { Link, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+dayjs.extend(customParseFormat);
+
+const onChange = (time, timeString) => {
+  console.log(time, timeString);
+};
+
+const TodoWrite = () => {
+  // 할 일
+  const [value, setValue] = useState("");
+  const { TextArea } = Input;
+
+  const navigate = useNavigate();
+
+  const [checkedValues, setCheckedValues] = useState(["없음"]);
+  const [isNoneChecked, setIsNoneChecked] = useState(true);
+
+  // check box
+
+  const plainOptions = ["없음"];
+
+  const handleCheckboxChange = e => {
+    const { value } = e.target;
+    setCheckedValues(value);
+  };
+
+  const handleDayCheckboxChange = e => {
+    const { checked, value: day } = e.target;
+    if (day === "없음") {
+      setIsNoneChecked(checked);
+      setCheckedValues(checked ? ["없음"] : []);
+    } else {
+      setIsNoneChecked(false);
+      let updatedCheckedValues = [];
+
+      if (checkedValues.includes("없음")) {
+        updatedCheckedValues = [day];
+      } else {
+        if (checked) {
+          updatedCheckedValues = [...checkedValues, day];
+        } else {
+          updatedCheckedValues = checkedValues.filter(value => value !== day);
+        }
+      }
+
+      if (updatedCheckedValues.length === 0) {
+        setIsNoneChecked(true);
+        setCheckedValues(["없음"]);
+      } else {
+        setIsNoneChecked(false);
+        setCheckedValues(updatedCheckedValues);
+      }
+    }
+  };
+
+  const handleNoneCheckboxChange = e => {
+    const { checked } = e.target;
+    if (checked) {
+      setIsNoneChecked(true);
+      setCheckedValues(["없음"]);
+    } else {
+      setIsNoneChecked(false);
+      setCheckedValues([]);
+    }
+  };
+
+  // 페이지 이동
+  const handleConfirm = () => {
+    navigate("/myplantlist");
+  };
+
+  // 시간선택 form
+
+  const { Option } = Select;
+  const layout = {
+    labelCol: {
+      span: 8,
+    },
+    wrapperCol: {
+      span: 16,
+    },
+  };
+  const tailLayout = {
+    wrapperCol: {
+      offset: 8,
+      span: 16,
+    },
+  };
+  const [form] = Form.useForm();
+  const onGenderChange = value => {
+    switch (value) {
+      case "male":
+        form.setFieldsValue({
+          note: "Hi, man!",
+        });
+        break;
+      case "female":
+        form.setFieldsValue({
+          note: "Hi, lady!",
+        });
+        break;
+      case "other":
+        form.setFieldsValue({
+          note: "Hi there!",
+        });
+        break;
+      default:
+    }
+  };
+
+  return (
+    <>
+      <ConfigProvider
+        theme={{
+          token: {
+            colorPrimary: mainColor.colorGreenRegular,
+          },
+        }}
+      >
+        <TodoWriteFir className="choise">
+          <TodoWriteTxt>식물 선택</TodoWriteTxt>
+          <Select
+            placeholder="원하는 반려 식물을 선택해 주세요."
+            allowClear
+            style={{ width: "100%" }}
+          ></Select>
+        </TodoWriteFir>
+
+        <TodoWriteFir className="time">
+          <TodoWriteTxt>시간 선택</TodoWriteTxt>
+          <Select
+            placeholder="00:00"
+            onChange={onGenderChange}
+            allowClear
+            style={{width: "30%"}}
+          >
+            <Option value="male">male</Option>
+            <Option value="female">female</Option>
+            <Option value="other">other</Option>
+          </Select>
+        </TodoWriteFir>
+
+        <TodoWriteFir className="todo">
+          <TodoWriteTxt>할 일</TodoWriteTxt>
+          <TextArea
+            value={value}
+            onChange={e => setValue(e.target.value)}
+            autoSize={{
+              minRows: 3,
+              maxRows: 5,
+            }}
+            style={{ width: "100%", paddingBottom: "148px" }}
+          />
+        </TodoWriteFir>
+      </ConfigProvider>
+
+      <TodoWriteFir className="repeat">
+        <TodoWriteTxt>반복여부</TodoWriteTxt>
+
+        <ConfigProvider
+          theme={{
+            components: {
+              Checkbox: {
+                colorPrimary: mainColor.colorGreenRegular,
+                colorPrimaryHover: mainColor.colorGreenRegular,
+              },
+            },
+          }}
+        >
+          <Checkbox.Group
+            options={plainOptions}
+            value={checkedValues}
+            onChange={handleCheckboxChange}
+            style={{ marginTop: "13px", fontSize: "1.4rem", fontWeight: 700 }}
+          />
+          <br />
+          <Checkbox
+            checked={isNoneChecked}
+            onChange={handleNoneCheckboxChange}
+            style={{ marginTop: "10px" }}
+          >
+            월
+          </Checkbox>
+          <Checkbox
+            checked={checkedValues.includes("화")}
+            onChange={handleDayCheckboxChange}
+            style={{ margin: "10px 0 0 10px" }}
+          >
+            화
+          </Checkbox>
+          <Checkbox
+            checked={checkedValues.includes("수")}
+            onChange={handleDayCheckboxChange}
+            style={{ margin: "10px 0 0 10px" }}
+          >
+            수
+          </Checkbox>
+          <Checkbox
+            checked={checkedValues.includes("목")}
+            onChange={handleDayCheckboxChange}
+            style={{ margin: "10px 0 0 10px" }}
+          >
+            목
+          </Checkbox>
+          <Checkbox
+            checked={checkedValues.includes("금")}
+            onChange={handleDayCheckboxChange}
+            style={{ margin: "10px 0 0 10px" }}
+          >
+            금
+          </Checkbox>
+          <Checkbox
+            checked={checkedValues.includes("토")}
+            onChange={handleDayCheckboxChange}
+            style={{ margin: "10px 0 0 10px" }}
+          >
+            토
+          </Checkbox>
+          <Checkbox
+            checked={checkedValues.includes("일")}
+            onChange={handleDayCheckboxChange}
+            style={{ margin: "10px 0 0 10px" }}
+          >
+            일
+          </Checkbox>
+        </ConfigProvider>
+        <br />
+      </TodoWriteFir>
+      <PageBtnWrap>
+        <li>
+          <button onClick={handleConfirm}>확인</button>
+        </li>
+        <li>
+          <button onClick={handleConfirm}>취소</button>
+        </li>
+      </PageBtnWrap>
+    </>
+  );
+};
+
+export default TodoWrite;

--- a/src/style/Components.js
+++ b/src/style/Components.js
@@ -210,7 +210,7 @@ export const PageBtnWrap = styled.ul`
   li {
     width: 100%;
     margin-right: 10px;
-    &:last-child {
+    &:last-of-type {
       margin-right: 0;
       a,
       button {

--- a/src/style/DetailLayout.js
+++ b/src/style/DetailLayout.js
@@ -95,7 +95,7 @@ export const MyPlantDetailTitle = styled.div`
   line-height: 1.2;
   padding: 25px 0 35px;
   text-align: center;
-  & > div:first-child {
+  & > div:first-of-type {
     font-size: 2.4rem;
     span {
       font-size: 0.7em;
@@ -104,7 +104,7 @@ export const MyPlantDetailTitle = styled.div`
     p {
     }
   }
-  & > div:last-child {
+  & > div:last-of-type {
     margin-top: 20px;
   }
   span {

--- a/src/style/IntroLayout.js
+++ b/src/style/IntroLayout.js
@@ -10,14 +10,14 @@ export const IntroWrap = styled.div`
     left: 50%;
     transform: translateX(-50%);
   }
-  & div:first-child {
+  & div:first-of-type {
     top: 32%;
     & > img {
       display: block;
       width: 100%;
     }
   }
-  & div:last-child {
+  & div:last-of-type {
     bottom: 10%;
     p {
       font-size: 2rem;

--- a/src/style/ListLayout.js
+++ b/src/style/ListLayout.js
@@ -56,7 +56,7 @@ export const ListItem = styled.li`
   isolation: isolate;
   box-sizing: border-box;
   height: 115px;
-  &:last-child {
+  &:last-of-type {
     margin-bottom: 0;
   }
   & > a {
@@ -149,7 +149,7 @@ export const ItemText = styled.div`
 export const MyPlantLiItem = styled.li`
   position: relative;
   margin-bottom: 15px;
-  &:last-child {
+  &:last-of-type {
     margin-bottom: 0;
   }
   & > a {
@@ -218,7 +218,7 @@ export const MyPlantLiItemDate = styled.div`
 export const DiaryLiItem = styled.li`
   position: relative;
   margin-bottom: 15px;
-  &:last-child {
+  &:last-of-type {
     margin-bottom: 0;
   }
   & > a {

--- a/src/style/NotFoundLayout.js
+++ b/src/style/NotFoundLayout.js
@@ -26,9 +26,7 @@ export const NotFoundWrap = styled.div`
         font-weight: 900;
         font-size: 2em;
       }
-      span:first-child {
-      }
-      span:last-child {
+      span:last-of-type {
         margin-bottom: 20px;
       }
     }

--- a/src/style/todocalendar.css
+++ b/src/style/todocalendar.css
@@ -104,7 +104,8 @@
 .react-calendar__month-view__days__day--neighboringMonth {
   color: rgba(0, 0, 0, 0.2) !important;
 }
-.react-calendar__month-view__days__day--neighboringMonth.highlight::before {
+.react-calendar__month-view__days__day--neighboringMonth.highlight
+  abbr::before {
   background: rgba(0, 0, 0, 0.2) !important;
 }
 .react-calendar__month-view__days__day--neighboringMonth::after {
@@ -216,6 +217,12 @@
 .sun_color {
   color: #fc4949;
 }
+.react-calendar__tile--now.sun_color {
+  color: #fff;
+}
 .sat_color {
   color: #5e64ff;
+}
+.react-calendar__tile--now.sat_color {
+  color: #fff;
 }


### PR DESCRIPTION
캘린더 주말-오늘 날짜 표시 스타일 겹쳤을 때 글자 색상 흰색으로 변경
지난달 todo 있는 날짜 표시 색상 글자 색상과 통일
수정 버튼 edit 페이지와 연결 작업
edit 페이지 path 이름 ~edit으로 통일
라우트 순서 리스트-쓰기-상세페이지-수정 순서로 통일